### PR TITLE
Remove conversion to Int32

### DIFF
--- a/common/scripted_effects/stat_file_exporter.txt
+++ b/common/scripted_effects/stat_file_exporter.txt
@@ -1,7 +1,7 @@
 ﻿export_country_GDPs_effect = {
 	debug_log = "Stat Export: Data Type: Date: Country Tag: Country Name: GDP"
 	every_country = {
-		debug_log = "Stat Export: Country GDP: [TimeKeeper.GetCurrentDate.GetString]: [THIS.GetCountry.GetTagName]: [THIS.GetCountry.GetNameNoFormatting]: [FixedPointToInt(THIS.GetCountry.GetGDP)]"
+		debug_log = "Stat Export: Country GDP: [TimeKeeper.GetCurrentDate.GetString]: [THIS.GetCountry.GetTagName]: [THIS.GetCountry.GetNameNoFormatting]: [THIS.GetCountry.GetGDP]"
 	}
 	debug_log = "Stat Export: Country GDP: End of Export"
 }
@@ -9,7 +9,7 @@
 export_state_GDPs_effect = {
 	debug_log = "Stat Export: Data Type: Date: State: Country Tag: Country Name: GDP"
 	every_state = {
-		debug_log = "Stat Export: State GDP: [TimeKeeper.GetCurrentDate.GetString]:[THIS.GetState.GetNameNoFormatting]: [THIS.GetState.GetOwner.GetTagName]: [THIS.GetState.GetOwner.GetNameNoFormatting]: [FixedPointToInt(THIS.GetState.GetGDPContribution)]"
+		debug_log = "Stat Export: State GDP: [TimeKeeper.GetCurrentDate.GetString]:[THIS.GetState.GetNameNoFormatting]: [THIS.GetState.GetOwner.GetTagName]: [THIS.GetState.GetOwner.GetNameNoFormatting]: [THIS.GetState.GetGDPContribution]"
 	}
 	debug_log = "Stat Export: State GDP: End of Export"
 }


### PR DESCRIPTION
Use original Fixed Point data type for GDP to avoid int32 overflow issues.